### PR TITLE
feat: add script to follow GNOME Shell logs in real-time

### DIFF
--- a/gnome-logs.sh
+++ b/gnome-logs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Follow GNOME Shell logs in real-time
+journalctl -f /usr/bin/gnome-shell


### PR DESCRIPTION
Create gnome-logs.sh to simplify monitoring of GNOME Shell logs
using journalctl. This helps developers and users quickly access
real-time logs for debugging and troubleshooting purposes.